### PR TITLE
Commented out "ri"/"dv"  serial messages. 

### DIFF
--- a/ky040.ts
+++ b/ky040.ts
@@ -29,8 +29,8 @@ namespace RotaryEncoder {
             while (true) {
                 const riValue = pins.digitalReadPin(ri);
                 const dvValue = pins.digitalReadPin(dv);
-                serial.writeValue("ri", riValue);
-                serial.writeValue("dv", dvValue);
+                // serial.writeValue("ri", riValue);
+                // serial.writeValue("dv", dvValue);
                 if (riValue == 1 && dvValue == 1) rotateReady = true;
                 else if (rotateReady) {
                     if (riValue == 1 && dvValue == 0) {


### PR DESCRIPTION
Thank you for writing this extension!  I use it in my class and it is great except one small detail:  the many  ri/dv serial messages drown out the students own serial messages.   This fork simply comments out the ri/dv serial messages.